### PR TITLE
Extra Vector Type Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bon"
 version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +543,12 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1149,8 +1167,10 @@ dependencies = [
 name = "qbice_serialize"
 version = "0.1.3"
 dependencies = [
+ "bitvec",
  "dashmap",
  "qbice_serialize_derive",
+ "smallvec",
 ]
 
 [[package]]
@@ -1166,11 +1186,13 @@ dependencies = [
 name = "qbice_stable_hash"
 version = "0.1.5"
 dependencies = [
+ "bitvec",
  "dashmap",
  "flexstr",
  "qbice_serialize",
  "qbice_stable_hash_derive",
  "siphasher",
+ "smallvec",
  "static_assertions",
 ]
 
@@ -1187,15 +1209,18 @@ dependencies = [
 name = "qbice_stable_type_id"
 version = "0.1.5"
 dependencies = [
+ "bitvec",
  "qbice_identifiable_derive",
  "qbice_serialize",
  "qbice_stable_hash",
+ "smallvec",
 ]
 
 [[package]]
 name = "qbice_storage"
 version = "0.6.3"
 dependencies = [
+ "bitvec",
  "bon",
  "crossbeam",
  "crossbeam-channel",
@@ -1212,6 +1237,7 @@ dependencies = [
  "rust-rocksdb",
  "scc",
  "siphasher",
+ "smallvec",
  "tempfile",
  "thread_local",
  "tokio",
@@ -1242,6 +1268,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rayon"
@@ -1531,6 +1563,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -1911,6 +1949,15 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ license = "MIT"
 siphasher = "1.0.1"
 static_assertions = "1.1.0"
 dashmap = { version = "6.1.0", features = ["rayon", "raw-api"] }
+smallvec = "1.15.1"
+bitvec = "1.0.1"
 flexstr = "0.9.1"
 quote = "1.0.42"
 syn = "2.0.111"

--- a/crates/identifiable_derive_lib/src/lib.rs
+++ b/crates/identifiable_derive_lib/src/lib.rs
@@ -17,14 +17,14 @@ pub fn implements_identifiable(
     if let Some(lt_param) = generics.lifetimes().next() {
         return syn::Error::new_spanned(
             lt_param,
-            "lifetime parameters are not allowed in key types",
+            "lifetime parameters are not allowed in key types for qbice::Identifiable",
         )
         .to_compile_error();
     }
     if let Some(const_param) = generics.const_params().next() {
         return syn::Error::new_spanned(
             const_param,
-            "constant parameters are not allowed in key types",
+            "constant parameters are not allowed in key types for qbice::Identifiable",
         )
         .to_compile_error();
     }

--- a/crates/qbice/Cargo.toml
+++ b/crates/qbice/Cargo.toml
@@ -18,6 +18,8 @@ default-config = ["rocksdb"]
 rocksdb = ["qbice_storage/rocksdb"]
 fjall = ["qbice_storage/fjall"]
 tracing_resource = ["qbice_storage/tracing_resource"]
+smallvec = [ "qbice_stable_hash/smallvec", "qbice_stable_type_id/smallvec", "qbice_serialize/smallvec", "qbice_storage/smallvec" ]
+bitvec = [ "qbice_stable_hash/bitvec", "qbice_stable_type_id/bitvec", "qbice_serialize/bitvec", "qbice_storage/bitvec" ]
 
 [dependencies]
 qbice_stable_hash = { version = "0.1.5", path = "../stable_hash" }

--- a/crates/serialize/Cargo.toml
+++ b/crates/serialize/Cargo.toml
@@ -7,9 +7,15 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+bitvec = ["dep:bitvec"]
+smallvec = ["dep:smallvec"]
+
 [dependencies]
 qbice_serialize_derive = { version = "0.1.0", path = "../serialize_derive" }
 dashmap.workspace = true
+smallvec = { workspace = true, optional = true }
+bitvec = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/serialize/src/decode.rs
+++ b/crates/serialize/src/decode.rs
@@ -672,7 +672,6 @@ where
         use bitvec::{mem::bits_of, vec::BitVec};
         use std::io::Write;
 
-        // TODO: Testing
         let len = decoder.read_usize()?;
         let number_of_bytes = len.div_ceil(bits_of::<u8>());
         let byte_vec = decoder.read_raw_bytes(number_of_bytes)?;

--- a/crates/serialize/src/decode.rs
+++ b/crates/serialize/src/decode.rs
@@ -13,7 +13,14 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(feature = "bitvec")]
+use bitvec::{
+    field::BitField, order::BitOrder, slice::BitSlice, store::BitStore,
+    vec::BitVec,
+};
 use dashmap::DashMap;
+#[cfg(feature = "smallvec")]
+use smallvec::{Array, SmallVec};
 
 use crate::{plugin::Plugin, session::Session};
 
@@ -632,6 +639,50 @@ impl<T: Decode> Decode for Vec<T> {
         for _ in 0..len {
             vec.push(T::decode(decoder, plugin, session)?);
         }
+        Ok(vec)
+    }
+}
+
+#[cfg(feature = "smallvec")]
+impl<T: Array> Decode for SmallVec<T> where T::Item: Decode {
+    fn decode<D: Decoder + ?Sized>(
+        decoder: &mut D,
+        plugin: &Plugin,
+        session: &mut Session,
+    ) -> io::Result<Self> {
+        let len = decoder.read_usize()?;
+        let mut vec = Self::with_capacity(len);
+        for _ in 0..len {
+            vec.push(T::Item::decode(decoder, plugin, session)?);
+        }
+        Ok(vec)
+    }
+}
+
+#[cfg(feature = "bitvec")]
+impl<T: Decode + BitStore, O: BitOrder> Decode for BitVec<T, O>
+where
+    BitSlice<T, O>: BitField,
+{
+    fn decode<D: Decoder + ?Sized>(
+        decoder: &mut D,
+        _plugin: &Plugin,
+        _session: &mut Session,
+    ) -> io::Result<Self> {
+        use bitvec::{mem::bits_of, vec::BitVec};
+        use std::io::Write;
+
+        // TODO: Testing
+        let len = decoder.read_usize()?;
+        let number_of_bytes = len.div_ceil(bits_of::<u8>());
+        let byte_vec = decoder.read_raw_bytes(number_of_bytes)?;
+        let mut vec = BitVec::new(); // Write will resize as needed.
+        let written = vec.write(byte_vec.as_slice())?;
+        assert!(
+            written == number_of_bytes,
+            "Should write the same number of bytes ({written}) as had been stored ({number_of_bytes})"
+        );
+        vec.truncate(len); // Ensure trailing bits aren't added.
         Ok(vec)
     }
 }

--- a/crates/serialize/src/encode.rs
+++ b/crates/serialize/src/encode.rs
@@ -559,7 +559,6 @@ impl<T: Encode + BitStore, O: BitOrder> Encode for BitVec<T, O> {
         plugin: &Plugin,
         session: &mut Session,
     ) -> io::Result<()> {
-        // TODO: Testing
         encoder.emit_usize(self.len())?;
         let underlying = self.as_raw_slice();
         for item in underlying {

--- a/crates/serialize/src/encode.rs
+++ b/crates/serialize/src/encode.rs
@@ -13,6 +13,10 @@ use std::{
 };
 
 use dashmap::DashMap;
+#[cfg(feature="smallvec")]
+use smallvec::{Array, SmallVec};
+#[cfg(feature="bitvec")]
+use bitvec::prelude::*;
 
 use crate::{plugin::Plugin, session::Session};
 
@@ -525,6 +529,40 @@ impl<T: Encode> Encode for Vec<T> {
     ) -> io::Result<()> {
         encoder.emit_usize(self.len())?;
         for item in self {
+            item.encode(encoder, plugin, session)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature="smallvec")]
+impl<T: Array> Encode for SmallVec<T> where T::Item: Encode {
+    fn encode<E: Encoder + ?Sized>(
+        &self,
+        encoder: &mut E,
+        plugin: &Plugin,
+        session: &mut Session,
+    ) -> io::Result<()> {
+        encoder.emit_usize(self.len())?;
+        for item in self {
+            item.encode(encoder, plugin, session)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature="bitvec")]
+impl<T: Encode + BitStore, O: BitOrder> Encode for BitVec<T, O> {
+    fn encode<E: Encoder + ?Sized>(
+        &self,
+        encoder: &mut E,
+        plugin: &Plugin,
+        session: &mut Session,
+    ) -> io::Result<()> {
+        // TODO: Testing
+        encoder.emit_usize(self.len())?;
+        let underlying = self.as_raw_slice();
+        for item in underlying {
             item.encode(encoder, plugin, session)?;
         }
         Ok(())

--- a/crates/serialize/src/postcard/test.rs
+++ b/crates/serialize/src/postcard/test.rs
@@ -1,3 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, LinkedList, VecDeque};
+use std::fmt::Debug;
+use dashmap::DashMap;
+
 use super::*;
 use crate::Plugin;
 
@@ -68,6 +72,179 @@ fn float_roundtrip() {
     assert_eq!(bytes.len(), 8); // f64 is always 8 bytes
     let decoded: f64 = decode(&bytes, &plugin).unwrap();
     assert_eq!(f64_value, decoded);
+}
+
+// =============================================================================
+// Container tests
+// =============================================================================
+
+fn roundtrip_values_unordered<C: Debug + IntoIterator + Encode + Decode>(value: C) where C::Item: PartialEq + Debug + Ord {
+    let plugin = Plugin::new();
+    let bytes = encode(&value, &plugin).unwrap();
+    assert!(!bytes.is_empty()); // Container should always produce bytes
+    let decoded: C = decode(&bytes, &plugin).unwrap();
+    let mut value_as_vec: Vec<C::Item> = value.into_iter().collect();
+    value_as_vec.sort();
+    let mut decoded_as_vec: Vec<C::Item> = decoded.into_iter().collect();
+    decoded_as_vec.sort();
+    assert_eq!(value_as_vec, decoded_as_vec);
+    // assert_eq!(value, decoded); // TODO: Use when `DashMap` implements `PartialEq`
+}
+
+fn roundtrip_values<C: Debug + IntoIterator + Encode + Decode + PartialEq>(value: C) where C::Item: PartialEq + Debug {
+    let plugin = Plugin::new();
+    let bytes = encode(&value, &plugin).unwrap();
+    assert!(!bytes.is_empty()); // Container should always produce bytes
+    let decoded: C = decode(&bytes, &plugin).unwrap();
+    assert_eq!(value, decoded);
+}
+
+#[test]
+fn vec_empty_roundtrip() {
+    roundtrip_values::<Vec<i32>>(vec![]);
+}
+
+#[test]
+fn vec_i32_roundtrip() {
+    roundtrip_values::<Vec<i32>>(vec![1, -2, 3]);
+}
+
+#[test]
+fn linkedlist_empty_roundtrip() {
+    roundtrip_values::<LinkedList<i32>>(LinkedList::from([]));
+}
+
+#[test]
+fn linkedlist_i32_roundtrip() {
+    roundtrip_values::<LinkedList<i32>>(LinkedList::from([1, -2, 3]));
+}
+
+#[test]
+fn vec_deque_empty_roundtrip() {
+    roundtrip_values::<VecDeque<i32>>(VecDeque::from(vec![]));
+}
+
+#[test]
+fn vec_deque_i32_roundtrip() {
+    roundtrip_values::<VecDeque<i32>>(VecDeque::from(vec![1, -2, 3]));
+}
+
+#[cfg(feature = "smallvec")]
+mod test_smallvec {
+    use smallvec::{smallvec, SmallVec};
+    use super::*;
+
+    #[test]
+    fn empty_roundtrip() {
+        roundtrip_values::<SmallVec<[i32; 2]>>(smallvec![]);
+    }
+
+    #[test]
+    fn i32_roundtrip() {
+        roundtrip_values::<SmallVec<[i32; 2]>>(smallvec![1, -2, 3]);
+    }
+}
+
+#[cfg(feature = "bitvec")]
+mod test_bitvec {
+    use bitvec::prelude::*;
+    use super::*;
+
+    #[test]
+    fn empty_roundtrip() {
+        roundtrip_values::<BitVec>(bitvec![]);
+    }
+
+    #[test]
+    fn i32_roundtrip() {
+        roundtrip_values::<BitVec>(bitvec![1, 0, 1, 1]);
+    }
+}
+
+// =============================================================================
+// Set tests
+// =============================================================================
+
+#[test]
+fn btreeset_empty_roundtrip() {
+    roundtrip_values_unordered::<BTreeSet<String>>(BTreeSet::new());
+}
+
+#[test]
+fn btreeset_i32_to_str_roundtrip() {
+    roundtrip_values_unordered::<BTreeSet<String>>(BTreeSet::from([
+        "one".to_owned(),
+        "two".to_owned(),
+        "three".to_owned(),
+        "negative three".to_owned(),
+    ]));
+}
+
+#[test]
+fn hashset_empty_roundtrip() {
+    roundtrip_values_unordered::<HashSet<String>>(HashSet::new());
+}
+
+#[test]
+fn hashset_i32_to_str_roundtrip() {
+    roundtrip_values_unordered::<HashSet<String>>(HashSet::from([
+        "one".to_owned(),
+        "two".to_owned(),
+        "three".to_owned(),
+        "negative three".to_owned(),
+    ]));
+}
+
+// =============================================================================
+// Map tests
+// =============================================================================
+
+#[test]
+fn btreemap_empty_roundtrip() {
+    roundtrip_values_unordered::<BTreeMap<i32, String>>(BTreeMap::new());
+}
+
+#[test]
+fn btreemap_i32_to_str_roundtrip() {
+    roundtrip_values_unordered::<BTreeMap<i32, String>>(BTreeMap::from([
+        (1, "one".to_owned()),
+        (2, "two".to_owned()),
+        (3, "three".to_owned()),
+        (-3, "negative three".to_owned()),
+    ]));
+}
+
+#[test]
+fn hashmap_empty_roundtrip() {
+    roundtrip_values_unordered::<HashMap<i32, String>>(HashMap::new());
+}
+
+#[test]
+fn hashmap_i32_to_str_roundtrip() {
+    roundtrip_values_unordered::<HashMap<i32, String>>(HashMap::from([
+        (1, "one".to_owned()),
+        (2, "two".to_owned()),
+        (3, "three".to_owned()),
+        (-3, "negative three".to_owned()),
+    ]));
+}
+
+#[test]
+fn dashmap_empty_roundtrip() {
+    roundtrip_values_unordered::<DashMap<i32, String>>(DashMap::new());
+}
+
+#[test]
+fn dashmap_i32_to_str_roundtrip() {
+    roundtrip_values_unordered::<DashMap<i32, String>>([
+        (1, "one".to_owned()),
+        (2, "two".to_owned()),
+        (3, "three".to_owned()),
+        (-3, "negative three".to_owned()),
+        ]
+        .into_iter()
+        .collect()
+    );
 }
 
 // =============================================================================

--- a/crates/stable_hash/Cargo.toml
+++ b/crates/stable_hash/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[features]
+bitvec = ["dep:bitvec"]
+smallvec = ["dep:smallvec"]
+
 [dependencies]
 siphasher.workspace = true
 static_assertions.workspace = true
@@ -14,6 +18,8 @@ dashmap.workspace = true
 flexstr.workspace = true
 qbice_serialize = { version = "0.1.1", path = "../serialize" }
 qbice_stable_hash_derive = { version = "0.1.3", path = "../stable_hash_derive" }
+bitvec = { workspace = true, optional = true}
+smallvec = { workspace = true, optional = true}
 
 [lints]
 workspace = true

--- a/crates/stable_hash/src/lib.rs
+++ b/crates/stable_hash/src/lib.rs
@@ -36,6 +36,11 @@ extern crate self as qbice_stable_hash;
 pub use qbice_stable_hash_derive::StableHash;
 use siphasher::sip128::Hasher128;
 
+#[cfg(feature = "bitvec")]
+use bitvec::prelude::*;
+#[cfg(feature = "smallvec")]
+use smallvec::{Array, SmallVec};
+
 #[doc(hidden)]
 pub mod __internal {}
 
@@ -440,6 +445,29 @@ impl StableHash for String {
 }
 
 impl<T: StableHash> StableHash for Vec<T> {
+    fn stable_hash<H: StableHasher + ?Sized>(&self, state: &mut H) {
+        state.write_length_prefix(self.len());
+        for item in self {
+            item.stable_hash(state);
+        }
+    }
+}
+
+#[cfg(feature = "smallvec")]
+impl<T: StableHash + Array> StableHash for SmallVec<T>
+where
+    T::Item: StableHash,
+{
+    fn stable_hash<H: StableHasher + ?Sized>(&self, state: &mut H) {
+        state.write_length_prefix(self.len());
+        for item in self {
+            item.stable_hash(state);
+        }
+    }
+}
+
+#[cfg(feature = "bitvec")]
+impl<T: StableHash + BitStore, O: BitOrder> StableHash for BitVec<T, O> {
     fn stable_hash<H: StableHasher + ?Sized>(&self, state: &mut H) {
         state.write_length_prefix(self.len());
         for item in self {

--- a/crates/stable_type_id/Cargo.toml
+++ b/crates/stable_type_id/Cargo.toml
@@ -7,10 +7,16 @@ description.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[features]
+bitvec = ["dep:bitvec"]
+smallvec = ["dep:smallvec"]
+
 [dependencies]
 qbice_stable_hash = { version = "0.1.5", path = "../stable_hash" }
 qbice_serialize = { version = "0.1.0", path = "../serialize" }
 qbice_identifiable_derive = { version = "0.1.1", path = "../identifiable_derive" }
+bitvec = { workspace = true, optional = true}
+smallvec = { workspace = true, optional = true}
 
 [lints]
 workspace = true

--- a/crates/stable_type_id/src/lib.rs
+++ b/crates/stable_type_id/src/lib.rs
@@ -551,11 +551,21 @@ impl<T: Array + Identifiable> Identifiable for SmallVec<T> {
 }
 
 #[cfg(feature = "bitvec")]
-impl<T: Identifiable + BitStore, O: Identifiable + BitOrder> Identifiable for BitVec<T, O> {
+impl<T: BitStore + Identifiable, O: BitOrder + Identifiable> Identifiable for BitVec<T, O> {
     const STABLE_TYPE_ID: StableTypeID = {
         let base = StableTypeID::from_unique_type_name("bitvec::BitVec");
         base.combine(T::STABLE_TYPE_ID).combine(O::STABLE_TYPE_ID)
     };
+}
+
+#[cfg(feature = "bitvec")]
+impl Identifiable for bitvec::order::Lsb0 {
+    const STABLE_TYPE_ID: StableTypeID = StableTypeID::from_unique_type_name("bitvec::order::Lsb0");
+}
+
+#[cfg(feature = "bitvec")]
+impl Identifiable for bitvec::order::Msb0 {
+    const STABLE_TYPE_ID: StableTypeID = StableTypeID::from_unique_type_name("bitvec::order::Msb0");
 }
 
 impl Identifiable for str {

--- a/crates/stable_type_id/src/lib.rs
+++ b/crates/stable_type_id/src/lib.rs
@@ -5,6 +5,12 @@ pub use qbice_identifiable_derive::Identifiable;
 use qbice_serialize::{Decode, Encode};
 pub use qbice_stable_hash::StableHash;
 
+#[cfg(feature = "smallvec")]
+use smallvec::{Array, SmallVec};
+
+#[cfg(feature = "bitvec")]
+use bitvec::prelude::*;
+
 /// A stable alternative to [`std::any::TypeId`] that is used to uniquely
 /// identify types in a way that is consistent across different runs of the
 /// compiler.
@@ -533,6 +539,22 @@ impl<T: Identifiable> Identifiable for Vec<T> {
     const STABLE_TYPE_ID: StableTypeID = {
         let base = StableTypeID::from_unique_type_name("std::vec::Vec");
         base.combine(T::STABLE_TYPE_ID)
+    };
+}
+
+#[cfg(feature = "smallvec")]
+impl<T: Array + Identifiable> Identifiable for SmallVec<T> {
+    const STABLE_TYPE_ID: StableTypeID = {
+        let base = StableTypeID::from_unique_type_name("smallvec::SmallVec");
+        base.combine(T::STABLE_TYPE_ID)
+    };
+}
+
+#[cfg(feature = "bitvec")]
+impl<T: Identifiable + BitStore, O: Identifiable + BitOrder> Identifiable for BitVec<T, O> {
+    const STABLE_TYPE_ID: StableTypeID = {
+        let base = StableTypeID::from_unique_type_name("bitvec::BitVec");
+        base.combine(T::STABLE_TYPE_ID).combine(O::STABLE_TYPE_ID)
     };
 }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,6 +11,8 @@ license.workspace = true
 rocksdb = ["dep:rust-rocksdb"]
 fjall = ["dep:fjall"]
 tracing_resource = ["dep:tracing"]
+smallvec = ["dep:smallvec", "qbice_serialize/smallvec", "qbice_stable_type_id/smallvec", "qbice_stable_hash/smallvec"]
+bitvec = ["dep:bitvec", "qbice_serialize/bitvec", "qbice_stable_type_id/bitvec", "qbice_stable_hash/bitvec"]
 
 [dependencies]
 qbice_serialize = { version = "0.1.3", path = "../serialize" }
@@ -31,6 +33,8 @@ ouroboros.workspace = true
 bon.workspace = true
 crossbeam.workspace = true
 scc.workspace = true
+smallvec = { workspace = true, optional = true }
+bitvec = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/storage/src/intern/test.rs
+++ b/crates/storage/src/intern/test.rs
@@ -366,6 +366,30 @@ fn deserialize_interned_value_shares_allocation() {
     assert!(Arc::ptr_eq(&decoded1.0, &interned.0));
 }
 
+#[cfg(feature = "bitvec")]
+#[test]
+fn serialize_deserialize_interned_bitvec_shares_allocation() {
+    use bitvec::prelude::*;
+
+    let shared = test_interner();
+    let mut plugin = Plugin::new();
+    plugin.insert(shared.clone());
+
+    let data = bitvec::bitvec![1, 0, 1, 1, 0, 1, 1];
+    let interned = shared.intern(data);
+
+    let bytes = encode_to_bytes(&interned, &plugin);
+
+    // Decode twice - both should share the same allocation from the interner
+    let decoded1: Interned<BitVec> = decode_from_bytes(&bytes, &plugin);
+    let decoded2: Interned<BitVec> = decode_from_bytes(&bytes, &plugin);
+
+    assert!(Arc::ptr_eq(&decoded1.0, &decoded2.0));
+    assert!(Arc::ptr_eq(&decoded1.0, &interned.0));
+    assert_eq!(&decoded1.0, &interned.0);
+    assert_eq!(&decoded2.0, &interned.0);
+}
+
 #[test]
 fn serialize_deserialize_tuple_with_duplicate_interned_values() {
     let shared = test_interner();
@@ -390,6 +414,35 @@ fn serialize_deserialize_tuple_with_duplicate_interned_values() {
 
 #[test]
 fn serialize_deserialize_vec_with_interned_values() {
+    let shared = test_interner();
+    let mut plugin = Plugin::new();
+    plugin.insert(shared.clone());
+
+    let data1 = TestData { name: "first".to_string(), value: 1 };
+    let data2 = TestData { name: "second".to_string(), value: 2 };
+    let data3 = TestData { name: "first".to_string(), value: 1 }; // Duplicate of data1
+
+    let vec: Vec<Interned<TestData>> =
+        vec![shared.intern(data1), shared.intern(data2), shared.intern(data3)];
+
+    // The first and third should share allocation
+    assert!(Arc::ptr_eq(&vec[0].0, &vec[2].0));
+
+    let bytes = encode_to_bytes(&vec, &plugin);
+    let decoded: Vec<Interned<TestData>> = decode_from_bytes(&bytes, &plugin);
+
+    assert_eq!(decoded.len(), 3);
+    assert_eq!(decoded[0].name, "first");
+    assert_eq!(decoded[1].name, "second");
+    assert_eq!(decoded[2].name, "first");
+
+    // The decoded first and third should also share allocation
+    assert!(Arc::ptr_eq(&decoded[0].0, &decoded[2].0));
+}
+
+#[cfg(feature = "smallvec")]
+#[test]
+fn serialize_deserialize_smallvec_with_interned_values() {
     let shared = test_interner();
     let mut plugin = Plugin::new();
     plugin.insert(shared.clone());


### PR DESCRIPTION
Add support for BitVec and SmallVec common compact representations for compilers with associated features to flag the implementation.
Also add some qualifiers to messages in compile time errors to make them easier to track back to QBICE.

https://docs.rs/smallvec/latest/smallvec/
https://docs.rs/bitvec/latest/bitvec/